### PR TITLE
Update chunkedUpsert.ts

### DIFF
--- a/src/app/utils/chunkedUpsert.ts
+++ b/src/app/utils/chunkedUpsert.ts
@@ -20,7 +20,7 @@ export const chunkedUpsert = async (
     await Promise.allSettled(
       chunks.map(async (chunk) => {
         try {
-          await index.namespace(namespace).upsert(vectors);
+          await index.namespace(namespace).upsert(chunk);
         } catch (e) {
           console.log('Error upserting chunk', e);
         }


### PR DESCRIPTION
The chunkedUpsert function is designed to split an array of PineconeRecord vectors into smaller chunks and upsert (insert or update) each chunk into a Pinecone index. It uses the sliceIntoChunks helper function to create the chunks based on the specified chunkSize.

## Problem
Using current code with large files will run into this error:

Error upserting chunk  [PineconeBadRequestError: Request size 3MB exceeds the maximum supported size of 2MB] {
  name: 'PineconeBadRequestError',
  cause: undefined


## Solution
There is a bug in the chunkedUpsert function. Inside the map callback, it should be upserting the chunk rather than the entire vectors array. This is likely the reason why the request size is exceeding the limit, as it's attempting to upsert the entire array of vectors in each iteration instead of just the chunk.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
