### PR TITLE
[spruce] Bump @pinecone-database version to support global control plane

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,9 +2,8 @@ OPENAI_API_KEY=
 
 # Retrieve the following from the Pinecone Console.
 
-# Navigate to API Keys under your Project to retrieve the API key and environment
+# Navigate to API Keys under your Project to retrieve the API key
 PINECONE_API_KEY=
-PINECONE_ENVIRONMENT=
 
 # Navigate to Indexes under your Project to retrieve the Index name
 PINECONE_INDEX=

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@pinecone-database/doc-splitter": "^0.0.1",
-        "@pinecone-database/pinecone": "^1.1.0",
+        "@pinecone-database/pinecone": "^1.1.2-spruceDev.20231214000822",
         "@types/node": "20.4.0",
         "@types/react": "18.2.14",
         "@types/react-dom": "18.2.6",
@@ -428,9 +428,9 @@
       }
     },
     "node_modules/@pinecone-database/pinecone": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@pinecone-database/pinecone/-/pinecone-1.1.0.tgz",
-      "integrity": "sha512-THg+D3cSYVCMmphroOEBQOU9UsOhABYcrExZyurcz8cZ3znipDyJuiX9F3CavysnQa5DTzQEZxcH1YmEMGW8mg==",
+      "version": "1.1.2-spruceDev.20231214000822",
+      "resolved": "https://registry.npmjs.org/@pinecone-database/pinecone/-/pinecone-1.1.2-spruceDev.20231214000822.tgz",
+      "integrity": "sha512-9VR3iFc47lVrIMlchaXAokaKe6esC1yEKoOStDkw109NKjJV+beqaSSNgKzzBdRc2Em3M+cGvCc7t0RaXhhfvw==",
       "dependencies": {
         "@edge-runtime/types": "^2.2.3",
         "@sinclair/typebox": "^0.29.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@pinecone-database/doc-splitter": "^0.0.1",
-    "@pinecone-database/pinecone": "^1.1.0",
+    "@pinecone-database/pinecone": "^1.1.2-spruceDev.20231214000822",
     "@types/node": "20.4.0",
     "@types/react": "18.2.14",
     "@types/react-dom": "18.2.6",

--- a/src/app/api/crawl/seed.ts
+++ b/src/app/api/crawl/seed.ts
@@ -37,11 +37,17 @@ async function seed(url: string, limit: number, indexName: string, options: Seed
 
     // Create Pinecone index if it does not exist
     const indexList = await pinecone.listIndexes();
-    const indexExists = indexList.some(index => index.name === indexName)
+    const indexExists = indexList.indexes?.some(index => index.name === indexName)
     if (!indexExists) {
       await pinecone.createIndex({
         name: indexName,
         dimension: 1536,
+        spec: {
+          serverless: {
+            region: 'us-west-2',
+            cloud: 'aws',
+          }
+        },
         waitUntilReady: true,
       });
     }

--- a/src/app/utils/embeddings.ts
+++ b/src/app/utils/embeddings.ts
@@ -12,7 +12,7 @@ export async function getEmbeddings(input: string) {
       model: "text-embedding-ada-002",
       input: input.replace(/\n/g, ' ')
     })
-
+    
     const result = await response.json();
     return result.data[0].embedding as number[]
 

--- a/src/app/utils/pinecone.ts
+++ b/src/app/utils/pinecone.ts
@@ -18,8 +18,8 @@ const getMatchesFromEmbeddings = async (embeddings: number[], topK: number, name
   }
 
   // Retrieve the list of indexes to check if expected index exists
-  const indexes = await pinecone.listIndexes()
-  if (indexes.filter(i => i.name === indexName).length !== 1) {
+  const indexList = await pinecone.listIndexes()
+  if (indexList.indexes?.filter(i => i.name === indexName).length !== 1) {
     throw new Error(`Index ${indexName} does not exist`)
   }
 


### PR DESCRIPTION
## Problem
We've been working to support the new global control plane service in the Pinecone clients. We need to update our sample apps to migrate to the new client versions, and update associated code paths as needed.

## Solution

- Bump the `@pinecone-database/pinecone` dependency to use the new `spruceDev` version of the client: `^1.1.2-spruceDev.20231214000822`.
- Update `pinecone.ts` and `seed.ts` to handle the new object response from `listIndexes()`.
- Update `seed.ts` to pass the proper config object shape to `createIndex()`.

For now, I've created a spruce branch to merge this into as we probably don't want to release sample apps that aren't aligned with what's available publicly.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## Test Plan
Run the playwright test suite and run the application locally:

![Screenshot 2023-12-18 at 3 23 32 PM](https://github.com/pinecone-io/pinecone-vercel-starter/assets/119623786/021f30e3-367b-4566-91b2-9aa78d227aeb)
![Screenshot 2023-12-18 at 3 24 44 PM](https://github.com/pinecone-io/pinecone-vercel-starter/assets/119623786/4dbb1647-9d17-4293-abe1-6356cdf5ed1c)
<img width="1006" alt="Screenshot 2023-12-18 at 3 24 08 PM" src="https://github.com/pinecone-io/pinecone-vercel-starter/assets/119623786/8d89b2e3-b6e1-4540-a6c2-f294b6758ae3">


